### PR TITLE
Minor spelling/grammar change

### DIFF
--- a/milvus_cli/Validation.py
+++ b/milvus_cli/Validation.py
@@ -29,7 +29,7 @@ def validateCollectionParameter(collectionName, primaryField, fields):
         fieldList = field.split(":")
         if not (len(fieldList) == 3):
             raise ParameterException(
-                'Field should contain three paremeters and concat by ":".'
+                'Field should contain three parameters concatenated by ":".'
             )
         [fieldName, fieldType, fieldData] = fieldList
         fieldNames.append(fieldName)
@@ -71,7 +71,7 @@ def validateIndexParameter(indexType, metricType, params):
         paramList = param.split(":")
         if not (len(paramList) == 2):
             raise ParameterException(
-                'Params should contain two paremeters and concat by ":".'
+                'Params should contain two parameters concatenated by ":".'
             )
         [paramName, paramValue] = paramList
         paramNames.append(paramName)
@@ -143,7 +143,7 @@ def validateSearchParams(
             paramList = param.split(":")
             if not (len(paramList) == 2):
                 raise ParameterException(
-                    'Params should contain two paremeters and concat by ":".'
+                    'Params should contain two parameters concatenated by ":".'
                 )
             [paramName, paramValue] = paramList
             if paramName not in SearchParams:


### PR DESCRIPTION
Just a minor change of `Paremeter -> Parameter` as well as it's phrasing.

---

Would also like to suggest that certain error messages can be improved somewhat.

An example would be, if incorrectly specifying the schema-field when creating a collection, we explicitly state that the format for should be `<fieldName>:<dataType>:<dimOfVector/desc>` like so:

```
milvus_cli > create collection -c book -f book_id:INT64 -f word_count:INT64 -f book_intro:FLOAT_VECTOR:2 -p book_id
Error!
Field schema should be in the `<fieldName>:<dataType>:<dimOfVector/desc>` format.
```

instead of

```
milvus_cli > create collection -c book -f book_id:INT64 -f word_count:INT64 -f book_intro:FLOAT_VECTOR:2 -p book_id
Error!
Field should contain three parameters and concat by ":".
```

Or at least refer users to the [Milvus_CLI Command Reference](https://milvus.io/docs/v2.1.x/cli_commands.md#Milvus_CLI-Command-Reference) for any "syntax errors"