### PR TITLE
Add COSINE metric to CLI

### DIFF
--- a/milvus_cli/Types.py
+++ b/milvus_cli/Types.py
@@ -111,6 +111,7 @@ MetricTypes = [
     "IP",
     "HAMMING",
     "TANIMOTO",
+    "COSINE",
     "",
 ]
 

--- a/milvus_cli/scripts/index_cli.py
+++ b/milvus_cli/scripts/index_cli.py
@@ -27,7 +27,7 @@ def createIndex(obj):
 
         Index type (FLAT, IVF_FLAT, IVF_SQ8, IVF_PQ, RNSG, HNSW, ANNOY,AUTOINDEX): IVF_FLAT
 
-        Index metric type (L2, IP, HAMMING, TANIMOTO): L2
+        Index metric type (L2, IP, HAMMING, TANIMOTO, COSINE): L2
 
         Index params nlist: 2
 


### PR DESCRIPTION
This is a possibly naive modification to add `COSINE` metric options for index management.  I'm using it locally with Milvus `2.3.0` successfully.