### PR TITLE
GPU_BRUTE_FORCE index enablement for CLI tool

### DIFF
--- a/milvus_cli/Types.py
+++ b/milvus_cli/Types.py
@@ -57,6 +57,7 @@ IndexTypes = [
     "STL_SORT",
     "Trie",
     "INVERTED",
+    "GPU_BRUTE_FORCE",
     "",
 ]
 
@@ -131,6 +132,10 @@ IndexTypesMap = {
     "SPARSE_WAND": {
         "index_building_parameters": ["drop_ratio_build"],
         "search_parameters": ["drop_ratio_search"],
+    },
+    "GPU_BRUTE_FORCE": {
+        "index_building_parameters": [],
+        "search_parameters": [],
     },
 }
 


### PR DESCRIPTION
GPU_BRUTE_FORCE index is tailored for cases where extremely high recall is crucial, guaranteeing a recall of 1 by comparing each query with all vectors in the dataset. 