### PR TITLE
update milvus-cli in dockerfile to 1.0.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 From python:3.8-slim
 
-RUN pip install milvus-cli==1.0.0
+RUN pip install milvus-cli==1.0.2
 RUN pip3 install protobuf==3.20.0 
 
 ENTRYPOINT ["milvus_cli"]


### PR DESCRIPTION
The milvus-cli version in dockerfile is 1.0.0, not as taged 1.0.2. We can't use the create role command.